### PR TITLE
replace AWS CLI action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - uses: chrislennon/action-aws-cli@1.1  # install AWS CLI
 
     - name: NPM Build
       if: github.ref == 'refs/heads/master'
@@ -29,24 +30,16 @@ jobs:
 
     - name: Deploy to S3
       if: github.ref == 'refs/heads/master'
-      uses: actions/aws/cli@master
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         BUCKET: access.datastage.io
-      with:
-        entrypoint: sh
-        args: -l -c "ls -al; cd build; ls -al; mkdir ../access-art && mv * ../access-art/.
-          && mv ../access-art/* .; aws s3 sync . s3://$BUCKET --delete --acl public-read"
+      run: ls -al; cd build; ls -al; mkdir ../access-art && mv * ../access-art/. && mv ../access-art/* .; aws s3 sync . s3://$BUCKET --delete --acl public-read
 
     - name: QA Deploy to S3
       if: github.ref != 'refs/heads/master'
-      uses: actions/aws/cli@master
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.QA_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.QA_AWS_SECRET_ACCESS_KEY }}
         BUCKET: qa-access.planx-pla.net
-      with:
-        entrypoint: sh
-        args: -l -c "ls -al; cd build; ls -al; mkdir ../access-art && mv * ../access-art/.
-          && mv ../access-art/* .; aws s3 sync . s3://$BUCKET --delete --acl public-read"
+      run: ls -al; cd build; ls -al; mkdir ../access-art && mv * ../access-art/. && mv ../access-art/* .; aws s3 sync . s3://$BUCKET --delete --acl public-read


### PR DESCRIPTION
`actions/aws/cli` isn't available anymore so workflows fail.
`chrislennon/action-aws-cli` is the most used 3rd party action i found to replace it. it works fine here: https://github.com/uc-cdis/stats.gen3.org/blob/master/.github/workflows/main.yml

### Bug Fixes
- Replace the AWS CLI GH action
